### PR TITLE
[feature] Add int8 kernel impls

### DIFF
--- a/include/ppl/kernel/llm/cuda/quant/common.h
+++ b/include/ppl/kernel/llm/cuda/quant/common.h
@@ -18,6 +18,7 @@
 # ifndef __PPL_KERNEL_LLM_CUDA_QUANT_H__
 # define __PPL_KERNEL_LLM_CUDA_QUANT_H__
 
+# define __HOST_DEVICE_FUNCTION__ __host__ __device__
 # include "ppl/kernel/llm/cuda/common/general_include.h"
 # include <cuda_fp16.h>
 
@@ -57,14 +58,14 @@ constexpr int32_t INT8_QMIN = -127;          // 量化最小值，改了就等�
 constexpr int32_t INT8_QMAX = +127;          // 量化最小值，改了就等着起飞
 
 template<typename Dtype>
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 Dtype CLIP(const Dtype v, const Dtype min, const Dtype max){
     if(v > max) return max;
     if(v < min) return min;
     return v;
 }
 
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 int _round2int(
     const float value,
     const int rounding
@@ -98,7 +99,7 @@ union FPConvertHelper {
 };
 
 template<typename Dtype, typename Stype, typename Otype>
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 float QuantizeScalarFloating(
     const Dtype value, const Stype scale, const Otype offset,
     const int exponent, const int mantissa,
@@ -176,7 +177,7 @@ float QuantizeScalarFloating(
 根据 scale 把 fp32 的数量化到 int8，这个东西似乎可以调用一个 __saturatef 指令加速运算，虽然它现在还没有
 https://github.com/openppl-public/ppq/blob/master/ppq/csrc/cuda/common.cuh#L118
 */
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 int8_t QUANT_FP32_TO_INT8(const fp32_t value, const fp32_t scale) {
     fp32_t _f_value = value / scale;
     int32_t _i_value = CLIP<int32_t>(
@@ -190,7 +191,7 @@ int8_t QUANT_FP32_TO_INT8(const fp32_t value, const fp32_t scale) {
 根据 scale的倒数 把 fp32 的数量化到 int8，这个东西似乎可以调用一个 __saturatef 指令加速运算，虽然它现在还没有
 https://github.com/openppl-public/ppq/blob/master/ppq/csrc/cuda/common.cuh#L118
 */
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 int8_t QUANT_FP32_TO_INT8_RCP(const fp32_t value, const fp32_t r_scale) {
     fp32_t _f_value = value * r_scale;
     int32_t _i_value = CLIP<int32_t>(
@@ -204,14 +205,14 @@ int8_t QUANT_FP32_TO_INT8_RCP(const fp32_t value, const fp32_t r_scale) {
 根据 min-max 范围确定 scale，这玩意跟 ppq 里面的实现很像，但它更简单一些
 https://github.com/openppl-public/ppq/blob/master/ppq/quantization/observer/range.py#L23
 */
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 fp32_t MIN_MAX_RANGE_TO_SCALE(const fp32_t range){
     assert(range > 0);
-    return max(min_max / 127, MINIMUM_QUANT_SCALE);
+    return max(range / 127, MINIMUM_QUANT_SCALE);
 }
 
 /* 快速求倒数，调一条原生指令 */
-__device__ inline
+__HOST_DEVICE_FUNCTION__ inline
 fp32_t RCP(const fp32_t value){
     return __frcp_rz(value);
 }

--- a/include/ppl/kernel/llm/cuda/quant/common.h
+++ b/include/ppl/kernel/llm/cuda/quant/common.h
@@ -1,0 +1,221 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# ifndef __PPL_KERNEL_LLM_CUDA_QUANT_H__
+# define __PPL_KERNEL_LLM_CUDA_QUANT_H__
+
+# include "ppl/kernel/llm/cuda/common/general_include.h"
+# include <cuda_fp16.h>
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant {
+
+/*
+Following code is coming from
+https://github.com/openppl-public/ppq/blob/master/ppq/csrc/cuda/common.cuh
+*/
+constexpr int32_t ROUND_HALF_EVEN          = 0;
+constexpr int32_t ROUND_HALF_UP            = 1;
+constexpr int32_t ROUND_HALF_DOWN          = 2;
+constexpr int32_t ROUND_HALF_TOWARDS_ZERO  = 3;
+constexpr int32_t ROUND_HALF_FAR_FORM_ZERO = 4;
+constexpr int32_t ROUND_TO_NEAR_INT        = 5;
+constexpr int32_t ROUND_UP                 = 6;
+constexpr int32_t ROUND_DOWN               = 7;
+
+// type define for quant
+using fp16_t   = half;
+using fp16x2_t = half2;
+
+using fp32_t   = float;
+using fp32x2_t = float2;
+using fp32x4_t = float4;
+
+using int16_t  = short int;
+
+using int8x2_t = char2;
+using int8x4_t = char4;
+
+using uint8x2_t = uchar2;
+using uint8x4_t = uchar4;
+
+constexpr fp32_t MINIMUM_QUANT_SCALE = 1e-7; // 量化最小 scale，改了也会起飞
+constexpr int32_t INT8_QMIN = -127;          // 量化最小值，改了就等着起飞
+constexpr int32_t INT8_QMAX = +127;          // 量化最小值，改了就等着起飞
+
+template<typename Dtype>
+__device__ inline
+Dtype CLIP(const Dtype v, const Dtype min, const Dtype max){
+    if(v > max) return max;
+    if(v < min) return min;
+    return v;
+}
+
+__device__ inline
+int _round2int(
+    const float value,
+    const int rounding
+){
+    switch(rounding){
+        case ROUND_HALF_EVEN:
+            return std::nearbyint(value);
+        case ROUND_HALF_UP:
+            return floor(value + .5);
+        case ROUND_HALF_DOWN:
+            return ceil(value - .5);
+        case ROUND_HALF_TOWARDS_ZERO:
+            if (value > 0) return _round2int(value, ROUND_HALF_DOWN);
+            else return _round2int(value, ROUND_HALF_UP);
+        case ROUND_HALF_FAR_FORM_ZERO:
+            if (value > 0) return _round2int(value, ROUND_HALF_UP);
+            else return _round2int(value, ROUND_HALF_DOWN);
+        case ROUND_UP:
+            return ceil(value);
+        case ROUND_DOWN:
+            return floor(value);
+        default:
+            return round(value);
+    }
+    return 0;
+}
+
+union FPConvertHelper {
+    float value;
+    uint32_t data;
+};
+
+template<typename Dtype, typename Stype, typename Otype>
+__device__ inline
+float QuantizeScalarFloating(
+    const Dtype value, const Stype scale, const Otype offset,
+    const int exponent, const int mantissa,
+    const float clip_min, const float clip_max, 
+    const Rounding rounding){
+    /**
+     * PPQ Quantization Function implementation.
+     * This function convert an float value to low-precision float
+     */
+    FPConvertHelper helper; FPConvertHelper rounding_helper;
+    float Unscaled_FP32 = static_cast<float>(value) / scale;
+    
+    helper.value = Unscaled_FP32;
+	int32_t exponent_min  = -(1 << (exponent - 1)) + 1;
+    int32_t exponent_max  = (1 << (exponent - 1));
+
+    // Following code will process exponent overflow
+    /* For FP8 E4M3, the maximum exponent value should be 8.                                  */
+    /* The Maximum number of FP8 E4M3 should be (0 1111 111) = 480                            */
+    /* We call it as theoretical_maximum, FP8 E4M3 can not represent a number larger than it. */
+    uint32_t fp32_sign    = 0;
+    int32_t fp32_exp      = (exponent_max + 127) << 23;
+    int32_t fp32_mantissa = ~(0x007FFFFF >> mantissa) & 0x007FFFFF;
+    helper.data = fp32_sign + fp32_mantissa + fp32_exp;
+    float theoretical_maximum = helper.value;
+
+    if (Unscaled_FP32 > min(clip_max, theoretical_maximum)) 
+        return min(clip_max, theoretical_maximum);
+    if (Unscaled_FP32 < max(clip_min, -theoretical_maximum)) 
+        return max(clip_min, -theoretical_maximum);
+
+    // Code start from here will convert number within fp8 range.
+    // Following code will Split float32 into sign, exp, mantissa
+    /* IEEE 754 Standard: 1 bit sign, 8 bit exponent, 23 bit mantissa */
+
+    /* In binary 10000000 00000000 00000000 00000000 = 0x80000000 in Hex */
+    /* In binary 01111111 10000000 00000000 00000000 = 0x7F800000 in Hex */
+    /* In binary 00000000 01111111 11111111 11111111 = 0x007FFFFF in Hex */
+
+    /* Tool: https://www.h-schmidt.net/FloatConverter/IEEE754.html */
+    helper.value  = Unscaled_FP32;
+    fp32_sign     = helper.data & 0x80000000;
+    fp32_exp      = helper.data & 0x7F800000;
+    fp32_mantissa = helper.data & 0x007FFFFF;
+
+    // Following code will process exponent underflow
+    /* Float underflow means fp32_exp is smaller than exponent_min          */
+    /* Where exponent_min is the minimum exponent value of quantized float. */
+    /* For FP8 E4M3, the minimum exponent value should be -7.               */
+    /* The Min Subnormal value of FP8 E4M3 should be (0 0000 001) = 2^-9    */
+    /* The Min normal value of FP8 E4M3 should be (0 0001 000) = 2^-6       */
+	if (((fp32_exp >> 23) - 127) < exponent_min + 1){
+        // following divide might have some problems
+        // but it is the simplest method with very limited error.
+        float min_subnormal = 1.0f / (1 << ((1 << (exponent - 1)) + mantissa - 2));
+        return _round2int(Unscaled_FP32 / min_subnormal, rounding) * min_subnormal;
+	}
+
+    /* high precision mantissa convert to low precision mantissa requires rounding                         */
+    /* Here we apply a tricky method to round mantissa:                                                    */
+    /* We create another float, which sign = 0, exponent = 127, mantissa = fp32_mantissa << (23 - mantissa) */
+    /* Then we directly round this float to int, result here is what we want, you can prove it by yourself */
+    rounding_helper.data = ((fp32_mantissa << (mantissa)) & 0x007FFFFF) + 0x3F800000;
+    uint32_t round_bit = _round2int(rounding_helper.value - 1, rounding);
+
+    // process mantissa
+    fp32_mantissa = ((fp32_mantissa >> (23 - mantissa)) + round_bit) << (23 - mantissa);
+    helper.data = fp32_sign + fp32_mantissa + fp32_exp;
+
+    return CLIP<float>(helper.value, clip_min, clip_max);
+
+}
+
+/*
+根据 scale 把 fp32 的数量化到 int8，这个东西似乎可以调用一个 __saturatef 指令加速运算，虽然它现在还没有
+https://github.com/openppl-public/ppq/blob/master/ppq/csrc/cuda/common.cuh#L118
+*/
+__device__ inline
+int8_t QUANT_FP32_TO_INT8(const fp32_t value, const fp32_t scale) {
+    fp32_t _f_value = value / scale;
+    int32_t _i_value = CLIP<int32_t>(
+        _round2int(_f_value, ROUND_HALF_EVEN),
+        INT8_QMIN, INT8_QMAX
+    );
+    return (int8_t)(_i_value);
+}
+
+/*
+根据 scale的倒数 把 fp32 的数量化到 int8，这个东西似乎可以调用一个 __saturatef 指令加速运算，虽然它现在还没有
+https://github.com/openppl-public/ppq/blob/master/ppq/csrc/cuda/common.cuh#L118
+*/
+__device__ inline
+int8_t QUANT_FP32_TO_INT8_RCP(const fp32_t value, const fp32_t r_scale) {
+    fp32_t _f_value = value * r_scale;
+    int32_t _i_value = CLIP<int32_t>(
+        _round2int(_f_value, ROUND_HALF_EVEN),
+        INT8_QMIN, INT8_QMAX
+    );
+    return (int8_t)(_i_value);
+}
+
+/*
+根据 min-max 范围确定 scale，这玩意跟 ppq 里面的实现很像，但它更简单一些
+https://github.com/openppl-public/ppq/blob/master/ppq/quantization/observer/range.py#L23
+*/
+__device__ inline
+fp32_t MIN_MAX_RANGE_TO_SCALE(const fp32_t range){
+    assert(range > 0);
+    return max(min_max / 127, MINIMUM_QUANT_SCALE);
+}
+
+/* 快速求倒数，调一条原生指令 */
+__device__ inline
+fp32_t RCP(const fp32_t value){
+    return __frcp_rz(value);
+}
+
+}}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/i8/column_parallel_linear.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/column_parallel_linear.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __PPL_KERNEL_LLM_CUDA_QUANT_I8_COLUMN_PARALLEL_LINEAR_H__
+#define __PPL_KERNEL_LLM_CUDA_QUANT_I8_COLUMN_PARALLEL_LINEAR_H__
+
+#include "ppl/kernel/llm/cuda/common/general_include.h"
+
+# include "ppl/kernel/llm/cuda/cublas/gemm.h"
+# include "ppl/common/cuda/nccl_utils.h"
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+ppl::common::RetCode column_parallel_linear_int8i_int32o(
+    const cudaStream_t stream,
+    const cublasLtHandle_t& cublaslt_handle,
+    const cublasLtMatmulAlgo_t* algo,
+    const ppl::common::TensorShape* input_shape,
+    const void* input,
+    const ppl::common::TensorShape* weight_shape,
+    const void* weight,
+    const ppl::common::TensorShape* bias_shape,
+    const void* bias,
+    const int64_t in_features,
+    const int64_t out_features,
+    ppl::common::NcclParam* nccl_param,
+    const bool gather_output,
+    void* gather_buffer,
+    const int64_t cublas_workspace_size,
+    void* cublas_workspace,
+    const ppl::common::TensorShape* output_shape,
+    void* output);
+}}}}}}

--- a/include/ppl/kernel/llm/cuda/quant/i8/core.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/core.h
@@ -20,6 +20,7 @@
 
 # include "ppl/kernel/llm/cuda/common/general_include.h"
 # include "ppl/kernel/llm/cuda/quant/common.h"
+# include "ppl/kernel/llm/cuda/quant/layout.h"
 
 namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
 

--- a/include/ppl/kernel/llm/cuda/quant/i8/core.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/core.h
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# ifndef __PPL_KERNEL_LLM_CUDA_QUANT_I8_CORE_H__
+# define __PPL_KERNEL_LLM_CUDA_QUANT_I8_CORE_H__
+
+# include "ppl/kernel/llm/cuda/common/general_include.h"
+# include "ppl/kernel/llm/cuda/quant/common.h"
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+/*
+The function performs group-wise dynamic de-quantization, 
+    which de-quantizes the int8 to fp16. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+ppl::common::RetCode groupwise_minmax_dequantize_int8i_fp16o(
+    cudaStream_t stream,
+    const int8_t* input,
+    const fp16_t* group_scale,
+    fp16_t* output,
+    const int64_t num_of_elements
+);
+
+/*
+The function performs group-wise dynamic quantization, 
+    which quantizes the fp16 to int8. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+ppl::common::RetCode groupwise_minmax_quantize_int8i_fp16o(
+    cudaStream_t stream,
+    const fp16_t* input,
+    fp16_t* group_scale,
+    int8_t* output,
+    int64_t num_of_elements
+);
+
+/*
+_channelwise_minmax_quantize_fp16i_i8o 用于执行 channelwise 的矩阵量化
+    输入矩阵必须形如 [input channel, output channel]，其 layout 的最后一维必须是 output channel
+    这个函数将生成一个形如 [output channel] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [input channel, output channel] 与解量化所需的 scale 向量 [output channel]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+
+    _channelwise_minmax_quantize_fp16i_i8o 访存不连续，性能很烂，但它通常是个预处理过程，没啥影响。
+*/
+ppl::common::RetCode channelwise_minmax_quantize_fp16i_i8o(
+    cudaStream_t stream,
+    const fp16_t *input // [dim or input channel, num_of_channel] 
+    const int64_t dim,
+    const int64_t num_of_channel,
+    fp16_t *scale_out, // [num_of_channel] 
+    int8_t *output
+);
+/*
+_tokenwise_minmax_quantize_fp16i_i8o 用于执行 tokenwise 的矩阵量化
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    这个函数将生成一个形如 [num of tokens] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [num of tokens, hidden dim] 与解量化所需的 scale 向量 [num of tokens]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+*/
+ppl::common::RetCode tokenwise_minmax_quantize_fp16i_i8o(
+    cudaStream_t stream,
+    const fp16_t *input, // [num of tokens, hidden dim]
+    const int64_t hidden_dim,
+    fp16_t *scale_out,
+    int8_t *output
+);
+
+/*
+token_channel_dequantize_i32i_f16o 用于执行 token + channel 的双重解量化
+    大语言模型的推理过程中参与矩阵乘的 num of tokens 会一直变化，我们可不想当它太大的时候造成量化误差过高
+    所以我们的矩阵乘法不仅仅是沿着 gemm output channel 量化的，其激活也会沿着 token 的方向量化
+
+    进行解量化时，我们要使用 output channel 与 token 的两种量化参数同时进行该操作。
+
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    参数矩阵必须同时传入 scale_per_token, scale_per_channel 两个
+
+    该函数将执行 output[i][j] = input[i][j] * scale_per_token[i] * scale_per_channel[j] 进行解量化
+    该函数在 batch 大约为 512 时可以打满访存带宽，好像 batch 大了反而菜一些
+*/
+ppl::common::RetCode token_channel_dequantize_i32i_f16o(
+    cudaStream_t stream,
+    int32_t *input,    // [num_of_token, hidden_dim] or [M, N]
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    const fp16_t *scale_per_token,   // [num_of_token]
+    const fp16_t *scale_per_channel, // [hidden_dim]
+    fp16_t *output     // [num_of_token, hidden_dim]
+);
+
+}}}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/i8/core.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/core.h
@@ -111,6 +111,7 @@ _tokenwise_minmax_quantize_fp16i_i8o 用于执行 tokenwise 的矩阵量化
 _channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
     channelwise, tokenwise 这样的命名方式更符合量化领域的规范
 */
+template<bool ConvertRowMajorToCol32>
 ppl::common::RetCode tokenwise_minmax_quantize_fp16i_i8o(
     cudaStream_t stream,
     const fp16_t *input, // [num of tokens, hidden dim]
@@ -132,6 +133,7 @@ token_channel_dequantize_i32i_f16o 用于执行 token + channel 的双重解量�
     该函数将执行 output[i][j] = input[i][j] * scale_per_token[i] * scale_per_channel[j] 进行解量化
     该函数在 batch 大约为 512 时可以打满访存带宽，好像 batch 大了反而菜一些
 */
+template<bool ConvertCol32ToRowMajor>
 ppl::common::RetCode token_channel_dequantize_i32i_f16o(
     cudaStream_t stream,
     int32_t *input,    // [num_of_token, hidden_dim] or [M, N]

--- a/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
@@ -20,6 +20,7 @@
 
 # include "ppl/kernel/llm/cuda/common/general_include.h"
 # include "ppl/kernel/llm/cuda/quant/common.h"
+# include "ppl/kernel/llm/cuda/quant/layout.h"
 
 namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
 /**

--- a/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# ifndef __PPL_KERNEL_LLM_CUDA_QUANT_I8_RMSNORM_H__
+# define __PPL_KERNEL_LLM_CUDA_QUANT_I8_RMSNORM_H__
+
+# include "ppl/kernel/llm/cuda/common/general_include.h"
+# include "ppl/kernel/llm/cuda/quant/common.h"
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+/**
+ * Skip Rmsnorm 与 动态量化 的融合算子
+ * 这个算子会执行 Add, Rmsnorm, Dynamic Quant 三个操作
+ * Dynamic Quant 是指这个算子会在运行时统计输入的 per token min-max 并以此对输入进行量化
+ * 使用公式 int8 value = clip(round(fp16 value / scale), -127, 127)
+ *     其中 scale = abs(max(fp16 value)) / 127
+ * 这个算子会执行 per token 量化，每一个 token 都将拥有一个属于它的 scale
+ *
+ * Skip Rmsnorm 会先执行 y1 = x + skip
+ *              而后执行 y2 = rmsnorm(y1)
+ * 返回 y1, y2 作为输出
+ */
+ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
+  const cudaStream_t stream,
+  const fp16_t *x,                // 输入，形如 [batch, hidden dim]
+  const fp16_t *weight,           // rmsnorm 的权重，形如 [hidden dim]
+  const fp16_t *skip,             // 求和项，这是 skip rmsnorm 中的另一个输入，形如 [batch, hidden dim]
+  const float eps,                // 1e-7
+  const int64_t num_of_batch      // x 第一维的大小
+  const int64_t normalize_shape,  // x 的最后一维大小
+  fp16_t *o1,                     // x + skip, 形如 [batch, hidden dim]
+  fp16_t *o2_scale,               // quant(rmsnorm(x + skip)), 形如 [batch]
+  int8_t *o2                      // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
+);
+
+}}}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
@@ -34,6 +34,7 @@ namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace qu
  *              而后执行 y2 = rmsnorm(y1)
  * 返回 y1, y2 作为输出
  */
+template<bool ConvertRowMajorToCol32>
 ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
   const cudaStream_t stream,
   const fp16_t *x,                // 输入，形如 [batch, hidden dim]

--- a/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/rmsnorm.h
@@ -42,9 +42,9 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
   const float eps,                // 1e-7
   const int64_t num_of_batch      // x 第一维的大小
   const int64_t normalize_shape,  // x 的最后一维大小
-  fp16_t *o1,                     // x + skip, 形如 [batch, hidden dim]
-  fp16_t *o2_scale,               // quant(rmsnorm(x + skip)), 形如 [batch]
-  int8_t *o2                      // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
+  fp16_t *skip_out,               // x + skip, 形如 [batch, hidden dim]
+  fp16_t *out_scale,              // quant(rmsnorm(x + skip)), 形如 [batch]
+  int8_t *out                     // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
 );
 
 }}}}}}

--- a/include/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.h
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __PPL_KERNEL_LLM_CUDA_QUANT_I8_ROW_PARALLEL_LINEAR_H__
+#define __PPL_KERNEL_LLM_CUDA_QUANT_I8_ROW_PARALLEL_LINEAR_H__
+
+#include "ppl/kernel/llm/cuda/common/general_include.h"
+
+#include "ppl/kernel/llm/cuda/cublas/gemm.h"
+#include "ppl/common/cuda/nccl_utils.h"
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+ppl::common::RetCode row_parallel_linear_int8i_int32o(
+    const cudaStream_t stream,
+    const cublasLtHandle_t& cublaslt_handle,
+    const cublasLtMatmulAlgo_t* algo,
+    const ppl::common::TensorShape* input_shape,
+    const void* input,
+    const ppl::common::TensorShape* weight_shape,
+    const void* weight,
+    const ppl::common::TensorShape* bias_shape,
+    const void* bias,
+    const int64_t in_features,
+    const int64_t out_features,
+    ppl::common::NcclParam* nccl_param,
+    const bool input_is_parallel,
+    void* split_buffer,
+    const int64_t cublas_workspace_size,
+    void* cublas_workspace,
+    const ppl::common::TensorShape* output_shape,
+    void* output);
+
+}}}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/i8/silu.h
+++ b/include/ppl/kernel/llm/cuda/quant/i8/silu.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# ifndef __PPL_KERNEL_LLM_CUDA_QUANT_I8_SILU_H__
+# define __PPL_KERNEL_LLM_CUDA_QUANT_I8_SILU_H__
+
+# include "ppl/kernel/llm/cuda/common/general_include.h"
+# include "ppl/kernel/llm/cuda/quant/common.h"
+# include "ppl/kernel/llm/cuda/quant/layout.h"
+
+using namespace ppl::kernel::llm::cuda::quant;
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+__DEVICE_INLINE_FUNCTION__
+fp32_t __silu_fp32(const fp32_t val){
+    return val / (1.f + __expf(-val));
+}
+
+__DEVICE_INLINE_FUNCTION__
+fp32_t __silu_fp16(const fp16_t val){
+    auto fp32 = __half2float(val);
+    return fp32 / (1.f + __expf(-fp32));
+}
+
+/*
+ * Silu 与 token-channel 解量化 与 token 量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize, Quantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 output_fp16 = silu(input) * gate
+ * 最后执行 output_int8 = dynamic per token quantize(output_fp16)
+ * 这个函数要求其输入输出排布均是 col32 的
+ * 
+ * 这个函数执行动态 per token 量化，
+*/
+template<bool GATED>
+ppl::common::RetCode silu_i32_i8_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32, 没有就直接传空指针
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token], 没有就直接传空指针
+    const fp16_t  *gate_channel_scale    // [hidden_dim], 没有就直接传空指针
+    fp16_t        *workspace             // [num_of_token, hidden_dim]
+    int8_t        *int8_output           // [num_of_token, hidden_dim]
+);
+
+/*
+ * Silu 与 token-channel 解量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 silu(input) * gate
+ * 这个函数要求其输入排布是 col32 的，可由参数 ConvertLayoutToRowMajor 决定在输出时是否使用 row major 排布
+*/
+template<bool GATED, bool ConvertLayoutToRowMajor>
+ppl::common::RetCode _silu_i32_fp16_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token]
+    const fp16_t  *gate_channel_scale    // [hidden_dim]
+    fp16_t        *fp16_output           // [num_of_token, hidden_dim]
+);
+
+}}}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/layout.h
+++ b/include/ppl/kernel/llm/cuda/quant/layout.h
@@ -1,0 +1,90 @@
+# include <assert.h>
+# include "common.h"
+
+# ifndef __PPL_KERNEL_LLM_CUDA_QUANT_LAYOUT_H__
+# define __PPL_KERNEL_LLM_CUDA_QUANT_LAYOUT_H__
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant {
+
+// CUDA Data Layout Explanation
+
+// Contiguous Memory Layout (Row-Major):
+// - Data elements are stored in adjacent memory locations.
+// - Similar to traditional CPU memory, where elements in a row are stored sequentially.
+// - Efficient when neighboring threads access neighboring elements in parallel,
+//   minimizing memory access latency.
+// - Suitable when data needs to be accessed in a row-wise or element-wise manner.
+// - Example: Suitable for 2D matrices when elements in the same row are frequently accessed together.
+
+// Strided Memory Layout (Column-Major):
+// - Data elements are stored with a specified stride between them.
+// - Useful when data access patterns are irregular, and threads access non-adjacent elements.
+// - Allows fine-grained control of memory access patterns.
+// - Suitable when different threads need to access different columns or non-adjacent elements.
+// - Accessing data in this layout is efficient for non-adjacent element access.
+
+// By ChatGPT
+
+/*
+    Layout Helper that convert row major index to col32 index.
+*/
+struct LayoutConverter {
+    using index_t = int;
+    index_t num_of_row; // num of row of given matrix.
+    index_t num_of_col; // num of col of given matrix.
+
+    LayoutConverter() = delete; // 别瞎几把初始化
+    
+    __HOST_DEVICE_FUNCTION__
+    LayoutConverter(index_t num_of_row, index_t num_of_col): 
+        num_of_row(num_of_row), num_of_col(num_of_col) {
+        // constructor
+    };
+
+    const __HOST_DEVICE_FUNCTION__
+    inline index_t RowColToOffset(
+        const index_t row, const index_t col){
+        return row * num_of_col + col;
+    }
+
+    const __HOST_DEVICE_FUNCTION__
+    inline index_t RowMajorToCol32(const index_t offset){
+        assert (offset < num_of_col * num_of_col);
+        constexpr index_t COL32 = 32;
+        
+        index_t row = offset / COL32;                            // row in col32 layout
+        index_t col = offset % COL32 + row / num_of_row * COL32; // col in col32 layout
+        return RowColToOffset(row, col);
+    }
+
+    const __HOST_DEVICE_FUNCTION__
+    inline index_t RowMajorToCol32(
+        const index_t row, const index_t col){
+        assert (row < num_of_row);
+        assert (col < num_of_col);
+        return RowMajorToCol32(RowColToOffset(row, col));
+    }
+
+    const __HOST_DEVICE_FUNCTION__
+    inline index_t Col32ToRowMajor(
+        const index_t offset){
+        assert (offset < num_of_col * num_of_col);
+        return Col32ToRowMajor(offset / num_of_col, offset % num_of_col);
+    }
+
+    const __HOST_DEVICE_FUNCTION__
+    inline index_t Col32ToRowMajor(
+        const index_t row, const index_t col){
+        constexpr index_t COL32 = 32;
+        assert (row < num_of_row);
+        assert (col < num_of_col);
+
+        index_t col_block_id = col / COL32;
+        index_t internal_id = col_block_id - col_block_id * COL32;
+        return col_block_id * num_of_row * COL32 + row * COL32 + internal_id;
+    }
+};
+
+}}}}
+
+# endif

--- a/include/ppl/kernel/llm/cuda/quant/layout.h
+++ b/include/ppl/kernel/llm/cuda/quant/layout.h
@@ -35,7 +35,7 @@ struct MatrixCoord{
         row_id(row_id), col_id(col_id) {
         // constructor
     }
-}
+};
 
 /*
     Layout Helper that convert row major index to col32 index.
@@ -53,13 +53,13 @@ struct LayoutConverter {
         // constructor
     };
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline index_t RowColToOffset(
         const index_t row, const index_t col){
         return row * num_of_col + col;
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline index_t RowMajorToCol32(const index_t offset){
         assert (offset < num_of_col * num_of_col);
         constexpr index_t COL32 = 32;
@@ -69,7 +69,7 @@ struct LayoutConverter {
         return RowColToOffset(row, col);
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline index_t RowMajorToCol32(
         const index_t row, const index_t col){
         assert (row < num_of_row);
@@ -77,14 +77,14 @@ struct LayoutConverter {
         return RowMajorToCol32(RowColToOffset(row, col));
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline index_t Col32ToRowMajor(
         const index_t offset){
         assert (offset < num_of_col * num_of_col);
         return Col32ToRowMajor(offset / num_of_col, offset % num_of_col);
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline index_t Col32ToRowMajor(
         const index_t row, const index_t col){
         constexpr index_t COL32 = 32;
@@ -96,7 +96,7 @@ struct LayoutConverter {
         return col_block_id * num_of_row * COL32 + row * COL32 + internal_id;
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline MatrixCoord Col32ToRowMajorCoord(
         const index_t row, const index_t col){
         constexpr index_t COL32 = 32;
@@ -109,7 +109,7 @@ struct LayoutConverter {
         return MatrixCoord(row_major_offset / num_of_col, row_major_offset % num_of_col);
     }
 
-    const __HOST_DEVICE_FUNCTION__
+    __HOST_DEVICE_FUNCTION__
     inline MatrixCoord Col32ToRowMajorCoord(
         const index_t offset){
         assert (offset < num_of_col * num_of_col);

--- a/src/ppl/kernel/llm/cuda/quant/i8/column_parallel_linear.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/column_parallel_linear.cu
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# include "ppl/kernel/llm/cuda/quant/column_parallel_linear.h"
+# include "ppl/common/log.h"
+
+# include "cudakernel/memory/transpose.h"
+
+# include <cuda_fp16.h>
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+ppl::common::RetCode column_parallel_linear_int8i_int32o(
+    const cudaStream_t stream,
+    const cublasLtHandle_t& cublaslt_handle,
+    const cublasLtMatmulAlgo_t* algo,
+    const ppl::common::TensorShape* input_shape,
+    const void* input,
+    const ppl::common::TensorShape* weight_shape,
+    const void* weight,
+    const ppl::common::TensorShape* bias_shape,
+    const void* bias,
+    const int64_t in_features,
+    const int64_t out_features,
+    ppl::common::NcclParam* nccl_param,
+    const bool gather_output,
+    void* gather_buffer,
+    const int64_t cublas_workspace_size,
+    void* cublas_workspace,
+    const ppl::common::TensorShape* output_shape,
+    void* output)
+{
+    // input (M, K)
+    // weight (N/w, K)
+    // gemm_output (M, Nw)
+    // output (M, N)
+
+    const int64_t M = input_shape->CalcElementsToDimensionExcludingPadding(input_shape->GetDimCount() - 1);
+    const int64_t Nw = out_features / nccl_param->size;
+    const int64_t K = in_features;
+
+    void *gemm_output = output;
+    if (gather_output && nccl_param->size > 1) {
+        gemm_output = (char*)gather_buffer
+            + nccl_param->rank * M * Nw * ppl::common::GetSizeOfDataType(output_shape->GetDataType());
+    }
+
+    ppl::common::RetCode status;
+
+    status = ppl::kernel::llm::cuda::cublas::gemm(
+        stream,
+        cublaslt_handle,
+        algo,
+        false,
+        K,
+        input_shape->GetDataType(),
+        input,
+        true,
+        K,
+        weight_shape->GetDataType(),
+        weight,
+        bias,
+        M,
+        Nw,
+        K,
+        1.0f,
+        0.0f,
+        cublas_workspace_size,
+        cublas_workspace,
+        Nw,
+        output_shape->GetDataType(),
+        gemm_output);
+
+    if (ppl::common::RC_SUCCESS != status)
+        return status;
+
+    if (gather_output && nccl_param->size > 1) {
+        status = ppl::common::NcclAllGather<half>(
+            (half*)gemm_output,
+            (half*)gather_buffer,
+            M * Nw,
+            nccl_param,
+            stream);
+        if (ppl::common::RC_SUCCESS != status)
+            return status;
+
+        // gather_buffer(w, M, N/w)
+        status = PPLCUDATranspose01ForwardImp(
+            stream, gather_buffer, 
+            output_shape->GetDataType(),
+            nccl_param->size,
+            M,
+            Nw,
+            output);
+        if (ppl::common::RC_SUCCESS != status)
+            return status;
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}}}

--- a/src/ppl/kernel/llm/cuda/quant/i8/core.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/core.cu
@@ -1,0 +1,478 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# include "ppl/kernel/llm/cuda/quant/common.h"
+# include "ppl/common/log.h"
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+/*
+    Function List:
+        __BlockReduceMax - 一个临时工，用来在 thread block 里面求最大值
+
+        groupwise_minmax_quantize_fp16i_int8o - 动态分组量化，fp16 输入，int8 输出
+
+        tokenwise_minmax_quantize_fp16i_i8o - 动态Token量化，fp16 输入，int8 输出
+        channelwise_minmax_quantize_fp16i_i8o - 静态通道量化，fp16 输入，int8 输出
+
+        token_channel_dequantize_i32i_f16o - token-channel 双重解量化，int32 输入， fp16 输出
+        groupwise_minmax_dequantize_int8i_fp16o - 动态分组解量化，int8 输入，fp16 输出
+*/
+
+using namespace ppl::kernel::llm::cuda::quant;
+
+/* Helper Function */
+template<int32_t WPT>
+__device__ inline
+fp32_t __BlockReduceMax(fp32_t reducing, fp32_t *shared_mem){
+    // Helper function for reduce softmax qkmax.
+    constexpr int32_t WARP_SIZE = 32;
+    const int32_t lane_id = threadIdx.x % WARP_SIZE;
+    const int32_t warp_id = threadIdx.x / WARP_SIZE;
+
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+        reducing = fmaxf(reducing, __shfl_xor_sync(uint32_t(-1), reducing, mask));
+    }
+
+    if (lane_id == 0) {
+        shared_mem[warp_id] = reducing;
+    }
+    __syncthreads();
+
+    if (lane_id < WPT) reducing = shared_mem[lane_id];
+    else reducing = -FLT_MAX;
+
+# pragma unroll
+    for (int mask = WPT / 2; mask >= 1; mask /= 2) {
+        reducing = fmaxf(reducing, __shfl_xor_sync(uint32_t(-1), reducing, mask));
+    }
+
+    reducing = __shfl_sync(uint32_t(-1), reducing, 0);
+    return reducing;
+}
+
+/*
+The function performs group-wise dynamic quantization, 
+    which quantizes the fp16 to int8. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+template<int TPB, int VPT> // 8 fp16 occupy 128 bytes, which can be loaded by a single thread at once.
+__global__
+void _groupwise_minmax_quantize_fp16i_int8o(
+    const fp16_t  *in,
+    const int32_t num_of_elements,
+    int8_t        *out,
+    fp16_t        *scale_out
+){
+    const int32_t idx = (blockIdx.x * TPB + threadIdx.x) * VPT;
+    fp16_t local_in[VPT]; int8_t local_out[VPT];
+
+    if (idx < num_of_elements){
+        copy<sizeof(fp16_t) * VPT>(&in[idx], local_in);
+        const fp16_t eps = __float2half(1e-5f);
+        fp16_t scale = __float2half(0.0f);
+
+    #pragma unroll
+        for(int i = 0; i < VPT; i ++){
+            scale = scale > abs(local_in[i]) ? scale : abs(local_in[i]);
+        }
+        scale = scale / __float2half(127.0f); 
+        scale = scale > eps ? scale : eps;
+    
+        scale_out[blockIdx.x * TPB + threadIdx.x] = scale;
+        fp16_t inv_s = __float2half(1.0f) / scale;
+    
+    #pragma unroll
+        for(int i = 0; i < VPT; i ++){
+            local_out[i] = (int8_t)__half2short_rn(local_in[i] * inv_s);
+        }
+        copy<sizeof(int8_t) * VPT>(local_out, &out[idx]);
+    }
+}
+
+
+/*
+The function performs group-wise dynamic de-quantization, 
+    which de-quantizes the int8 to fp16. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+template<int TPB, int VPT>
+__global__
+void _groupwise_minmax_dequantize_int8i_fp16o(
+    const int8_t  *in,
+    const int32_t  num_of_elements,
+    fp16_t        *out,
+    const fp16_t  *scale
+){
+    const int32_t idx = (blockIdx.x * TPB + threadIdx.x) * VPT;
+    int8_t local_in[VPT]; fp16_t local_out[VPT];
+
+    if (idx < num_of_elements){
+        copy<sizeof(int8_t) * VPT>(&in[idx], local_in);
+
+    #pragma unroll
+        for(int i = 0; i < VPT; i ++){
+            local_out[i] = __float2half((float)local_in[i]) * scale[blockIdx.x * TPB + threadIdx.x];
+        }
+        copy<sizeof(fp16_t) * VPT>(local_out, &out[idx]);
+    }
+}
+
+/*
+_channelwise_minmax_quantize_fp16i_i8o 用于执行 channelwise 的矩阵量化
+    输入矩阵必须形如 [input channel, output channel]，其 layout 的最后一维必须是 output channel
+    这个函数将生成一个形如 [output channel] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [num_of_token, num_of_channel] 与解量化所需的 scale 向量 [output channel]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+
+    _channelwise_minmax_quantize_fp16i_i8o 访存不连续，性能很烂，但它通常是个预处理过程，没啥影响。
+*/
+template<int32_t TPB>
+__global__
+void _channelwise_minmax_quantize_fp16i_i8o(
+    const fp16_t *in, // [num_of_token, num_of_channel]
+    const int32_t dim,
+    const int32_t num_of_channel,
+    fp16_t *scale_out, int8_t *out
+){
+    const int32_t tile_idx    = blockIdx.x;
+    const int32_t tile_offset = tile_idx * TPB;
+    const int32_t local_idx   = tile_offset + threadIdx.x;
+
+    if (local_idx < num_of_channel){
+        fp32_t channel_max = 0.0f;
+        for(int32_t i = 0; i < dim; i++){
+            fp32_t value = __half2float(in[i * num_of_channel + local_idx]);
+            channel_max = max(abs(value), channel_max);
+        }
+
+        fp32_t scale = MIN_MAX_RANGE_TO_SCALE(channel_max);
+        for(int32_t i = 0; i < dim; i++){
+            out[i * num_of_channel + local_idx] = QUANT_FP32_TO_INT8(
+                __half2float(in[i * num_of_channel + local_idx]), scale
+            );
+        }
+
+        scale_out[local_idx] = __float2half(scale);
+    }
+}
+
+/*
+_tokenwise_minmax_quantize_fp16i_i8o 用于执行 tokenwise 的矩阵量化
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    这个函数将生成一个形如 [num of tokens] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [num of tokens, hidden dim] 与解量化所需的 scale 向量 [num of tokens]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+*/
+template<int32_t TPB>
+__global__
+void _tokenwise_minmax_quantize_fp16i_i8o(
+    const fp16_t *in, // [token, hidden_dim]
+    const int32_t hidden_dim,
+    fp16_t *scale_out,
+    int8_t *out
+) {
+    constexpr int32_t WPT      = TPB / 32; // warp per thread block
+    const int32_t batch_id     = blockIdx.x;
+    const int32_t batch_offset = batch_id * hidden_dim;
+    __shared__ fp32_t red_smem[WPT];
+
+    fp32_t local_max = 0.0f;
+    for(int32_t i = threadIdx.x; i < hidden_dim; i += TPB){
+        fp32_t value = __half2float(in[batch_offset + i]);
+        local_max = max(abs(value), local_max);
+    }
+    local_max = __BlockReduceMax<WPT>(local_max, red_smem);
+    fp32_t scale = MIN_MAX_RANGE_TO_SCALE(local_max);
+
+    for(int32_t i = threadIdx.x; i < hidden_dim; i += TPB){
+        fp32_t fp_value = __half2float(in[batch_offset + i]);
+        out[batch_offset + i] = QUANT_FP32_TO_INT8(fp_value, scale);
+    }
+    if(threadIdx.x == 0){
+        scale_out[batch_id] = __float2half(scale);
+    }
+}
+
+/*
+_token_channel_dequantize_i32i_f16o 用于执行 token + channel 的双重解量化
+    大语言模型的推理过程中参与矩阵乘的 num of tokens 会一直变化，我们可不想当它太大的时候造成量化误差过高
+    所以我们的矩阵乘法不仅仅是沿着 gemm output channel 量化的，其激活也会沿着 token 的方向量化
+
+    进行解量化时，我们要使用 output channel 与 token 的两种量化参数同时进行该操作。
+
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    参数矩阵必须同时传入 scale_per_token, scale_per_channel 两个
+
+    该函数将执行 output[i][j] = input[i][j] * scale_per_token[i] * scale_per_channel[j] 进行解量化
+    该函数在 batch 大约为 512 时可以打满访存带宽，好像 batch 大了反而菜一些
+*/
+template<int32_t TPB, int32_t VPT>
+__global__
+void _token_channel_dequantize_i32i_f16o(
+    int32_t *in,    // [num_of_token, hidden_dim] or [M, N]
+    const int32_t batch_size,
+    const int32_t hidden_dim,
+    const fp16_t *scale_per_batch,
+    const fp16_t *scale_per_channel,
+    fp16_t *out
+) {
+    const int32_t batch_id = blockIdx.y;
+    const int32_t batch_offset = batch_id * hidden_dim;
+    const int32_t tile_id  = blockIdx.x;
+    const int32_t tile_offset = tile_id * TPB * VPT;
+
+    int32_t local_in[VPT]; fp16_t local_w[VPT];
+    copy<sizeof(int32_t) * VPT>(&in[batch_offset + tile_offset + threadIdx.x * VPT], local_in);
+    copy<sizeof(fp16_t) * VPT>(&scale_per_channel[tile_offset + threadIdx.x * VPT], local_w);
+    
+    fp32_t batch_scale = __half2float(scale_per_batch[batch_id]);
+    fp16_t local_out[VPT];
+    # pragma unroll
+    for(int32_t i = 0; i < VPT; i++){
+        local_out[i] = __float2half(local_in[i] * __half2float(local_w[i]) * batch_scale);
+    }
+    copy<sizeof(fp16_t) * VPT>(local_out, &out[batch_offset + tile_offset + threadIdx.x * VPT]);
+    
+}
+
+/*
+The function performs group-wise dynamic de-quantization, 
+    which de-quantizes the int8 to fp16. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+ppl::common::RetCode groupwise_minmax_dequantize_int8i_fp16o(
+    cudaStream_t stream,
+    const int8_t* input,
+    const fp16_t* group_scale,
+    fp16_t* output,
+    const int64_t num_of_elements
+){
+    constexpr int32_t VPT = 16 / sizeof(fp16_t);
+    constexpr int32_t TPB = 256;
+    const int32_t grid_size = num_of_elements / VPT / TPB + (num_of_elements % (VPT * TPB) != 0);
+
+    if (num_of_elements % 8 != 0){
+        LOG(ERROR) << "Input data length must be a multiple of 8.";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    _groupwise_minmax_dequantize_int8i_fp16o<TPB, VPT>
+    <<<grid_size, TPB, 0, stream>>>(
+        input, num_of_elements, 
+        output, group_scale
+    );
+    return ppl::common::RC_SUCCESS;
+}
+
+/*
+The function performs group-wise dynamic quantization, 
+    which quantizes the fp16 to int8. 
+
+group-wise quantization means that the quantization granularity of this function is extremely small. 
+    Typically, we perform per-tensor or per-channel quantization because only these two quantization schemes have 
+    high-performance implementations for matrix multiplication. 
+
+However, this function is designed for the temporary storage of kv and does not involve any calculation issues.
+Therefore, we can design a new quantization scheme to obtain lower quantization bit widths or higher quantization precision. 
+
+We define a group as k(k=8 in most cases) adjacent elements, and the elements in the group share a set of quantization parameters. 
+The quantization granularity of this quantization scheme is extremely small, thus it has extremely high quantization precision.
+
+The so-called dynamic quantization means that each input quantization parameter is calculated in real-time, 
+    rather than being given by a calibration function.
+*/
+ppl::common::RetCode groupwise_minmax_quantize_int8i_fp16o(
+    cudaStream_t stream,
+    const fp16_t* input,
+    fp16_t* group_scale,
+    int8_t* output,
+    int64_t num_of_elements
+){
+    constexpr int32_t VPT = 16 / sizeof(fp16_t);
+    constexpr int32_t TPB = 256;
+    const int32_t grid_size = x.numel() / VPT / TPB + (x.numel() % (VPT * TPB) != 0);
+
+    if (num_of_elements % 8 != 0){
+        LOG(ERROR) << "Input data length must be a multiple of 8.";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    _groupwise_minmax_quantize_int8i_fp16o<TPB, VPT>
+    <<<grid_size, TPB, 0, stream>>>(
+        input, num_of_elements, 
+        output, group_scale
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+
+/*
+_channelwise_minmax_quantize_fp16i_i8o 用于执行 channelwise 的矩阵量化
+    输入矩阵必须形如 [input channel, output channel]，其 layout 的最后一维必须是 output channel
+    这个函数将生成一个形如 [output channel] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [input channel, output channel] 与解量化所需的 scale 向量 [output channel]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+
+    _channelwise_minmax_quantize_fp16i_i8o 访存不连续，性能很烂，但它通常是个预处理过程，没啥影响。
+*/
+ppl::common::RetCode channelwise_minmax_quantize_fp16i_i8o(
+    cudaStream_t stream,
+    const fp16_t *input // [dim or input channel, num_of_channel] 
+    const int64_t dim,
+    const int64_t num_of_channel,
+    fp16_t *scale_out, // [num_of_channel] 
+    int8_t *output
+) {
+    constexpr int32_t TPB = 256;
+    const int32_t num_of_thread_block = num_of_out_channel / TPB + (num_of_out_channel % TPB != 0);
+
+    _channelwise_minmax_quantize_fp16i_i8o<TPB>
+    <<<num_of_thread_block, TPB, 0, stream>>>(
+        input, dim, num_of_channel,
+        scale_out, output
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+/*
+_tokenwise_minmax_quantize_fp16i_i8o 用于执行 tokenwise 的矩阵量化
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    这个函数将生成一个形如 [num of tokens] 的 scale 向量用于量化
+    
+    该函数沿着 input channel 的方向统计通道最大值(取绝对值)，并使得 scale = max_value / 127
+    该函数要求 scale 必须大于 1e-7，否则将以该值进行覆盖，因此不会出现 scale = 0 的问题
+    该函数会使用生成的 scale 完成对输入矩阵的量化，限制其表示范围在 [-127, 127] 之间。
+
+    该函数返回两个值，分别是量化后的矩阵 [num of tokens, hidden dim] 与解量化所需的 scale 向量 [num of tokens]
+
+_channelwise_minmax_quantize_fp16i_i8o 与 _tokenwise_minmax_quantize_fp16i_i8o 的区别其实就是一个沿着第一维统计量化，另一个沿着最后一维统计量化。
+    channelwise, tokenwise 这样的命名方式更符合量化领域的规范
+*/
+ppl::common::RetCode tokenwise_minmax_quantize_fp16i_i8o(
+    cudaStream_t stream,
+    const fp16_t *input, // [num of tokens, hidden dim]
+    const int64_t hidden_dim,
+    fp16_t *scale_out,
+    int8_t *output
+) {
+    constexpr int32_t TPB = 256;
+    _tokenwise_minmax_quantize_fp16i_i8o<TPB>
+    <<<num_of_batch, TPB, 0, stream>>>(
+        input, hidden_dim,
+        scale_out, output
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+/*
+token_channel_dequantize_i32i_f16o 用于执行 token + channel 的双重解量化
+    大语言模型的推理过程中参与矩阵乘的 num of tokens 会一直变化，我们可不想当它太大的时候造成量化误差过高
+    所以我们的矩阵乘法不仅仅是沿着 gemm output channel 量化的，其激活也会沿着 token 的方向量化
+
+    进行解量化时，我们要使用 output channel 与 token 的两种量化参数同时进行该操作。
+
+    输入矩阵必须形如 [num of tokens, hidden dim]，其 layout 的第一维必须是 num of tokens
+    参数矩阵必须同时传入 scale_per_token, scale_per_channel 两个
+
+    该函数将执行 output[i][j] = input[i][j] * scale_per_token[i] * scale_per_channel[j] 进行解量化
+    该函数在 batch 大约为 512 时可以打满访存带宽，好像 batch 大了反而菜一些
+*/
+ppl::common::RetCode token_channel_dequantize_i32i_f16o(
+    cudaStream_t stream,
+    int32_t *input,    // [num_of_token, hidden_dim] or [M, N]
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    const fp16_t *scale_per_token,   // [num_of_token]
+    const fp16_t *scale_per_channel, // [hidden_dim]
+    fp16_t *output     // [num_of_token, hidden_dim]
+) {
+    constexpr int32_t TPB = 256;
+    constexpr int32_t VPT = 4;
+    const dim3 block_grid {hidden_dim / (TPB*VPT), num_of_token, 1};
+    
+    _token_channel_dequantize_i32i_f16o<TPB, VPT>
+    <<<block_grid, TPB, 0, stream>>> (
+        input, num_of_token, hidden_dim,
+        scale_per_token, scale_per_channel,
+        output
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}}}}

--- a/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
@@ -114,9 +114,9 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
   const float eps,                // 1e-7
   const int64_t num_of_batch      // x 第一维的大小
   const int64_t normalize_shape,  // x 的最后一维大小
-  fp16_t *o1,                     // x + skip, 形如 [batch, hidden dim]
-  fp16_t *o2_scale,               // quant(rmsnorm(x + skip)), 形如 [batch]
-  int8_t *o2                      // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
+  fp16_t *skip_out,               // x + skip, 形如 [batch, hidden dim]
+  fp16_t *out_scale,              // quant(rmsnorm(x + skip)), 形如 [batch]
+  int8_t *out                     // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
 ) {
 /*
   Merged Impl of Skip Rmsnorm + PerToken Quant(fp16 input, int8 output)
@@ -132,10 +132,11 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
       x,
       weight,
       skip,
-      eps, normalize_shape,
-      o1,
-      o2_scale,
-      o2
+      eps, 
+      normalize_shape,
+      skip_out,
+      out_scale,
+      out
     );
     break;
   case 1024:
@@ -144,10 +145,11 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
       x,
       weight,
       skip,
-      eps, normalize_shape,
-      o1,
-      o2_scale,
-      o2
+      eps, 
+      normalize_shape,
+      skip_out,
+      out_scale,
+      out
     );
     break;
   case 4096:
@@ -156,10 +158,11 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
       x,
       weight,
       skip,
-      eps, normalize_shape,
-      o1,
-      o2_scale,
-      o2
+      eps, 
+      normalize_shape,
+      skip_out,
+      out_scale,
+      out
     );
     break;
   case 8192:
@@ -168,10 +171,11 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
       x,
       weight,
       skip,
-      eps, normalize_shape,
-      o1,
-      o2_scale,
-      o2
+      eps, 
+      normalize_shape,
+      skip_out,
+      out_scale,
+      out
     );
     break;
   default:

--- a/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# include "ppl/kernel/llm/cuda/quant/common.h"
 # include "ppl/kernel/llm/cuda/quant/i8/rmsnorm.h"
-# include "ppl/kernel/llm/cuda/quant/layout.h"
 # include "ppl/common/log.h"
 
 using namespace ppl::kernel::llm::cuda::quant;
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
 
 /**
  * Skip Rmsnorm 与 动态量化 的融合算子
@@ -205,3 +205,5 @@ ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
   };
   return ppl::common::RC_SUCCESS;
 }
+
+}}}}}}

--- a/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/rmsnorm.cu
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# include "ppl/kernel/llm/cuda/quant/common.h"
+# include "ppl/kernel/llm/cuda/quant/i8/rmsnorm.h"
+# include "ppl/common/log.h"
+
+/**
+ * Skip Rmsnorm 与 动态量化 的融合算子
+ * 这个算子会执行 Add, Rmsnorm, Dynamic Quant 三个操作
+ * Dynamic Quant 是指这个算子会在运行时统计输入的 per token min-max 并以此对输入进行量化
+ * 使用公式 int8 value = clip(round(fp16 value / scale), -127, 127)
+ *     其中 scale = abs(max(fp16 value)) / 127
+ * 这个算子会执行 per token 量化，每一个 token 都将拥有一个属于它的 scale
+ *
+ * Skip Rmsnorm 会先执行 y1 = x + skip
+ *              而后执行 y2 = rmsnorm(y1)
+ * 返回 y1, y2 作为输出
+ */
+ template <int VPT, int TPB>
+__global__
+void _skip_rmsnorm_with_minmax_quant_fp16i_int8o(
+  const fp16_t *x,                // 输入，形如 [batch, hidden dim]
+  const fp16_t *weight,           // rmsnorm 的权重，形如 [hidden dim]
+  const fp16_t *skip,             // 求和项，这是 skip rmsnorm 中的另一个输入，形如 [batch, hidden dim]
+  const float eps,                // 1e-7
+  const int32_t normalize_shape,  // x 的最后一维大小
+  fp16_t *o1,                     // x + skip
+  fp16_t *o2_scale,               // quant(rmsnorm(x + skip))
+  int8_t *o2                      // quant(rmsnorm(x + skip))
+){
+  const int32_t idx = normalize_shape * blockIdx.x + threadIdx.x * VPT;
+  fp16_t inLocal[VPT]; fp16_t weightLocal[VPT];
+
+  copy<sizeof(fp16_t) * VPT>(&x[idx], inLocal);
+  copy<sizeof(fp16_t) * VPT>(&skip[idx], weightLocal);
+
+  fp32_t accumulator = 0.0f; // accumulator
+  fp32_t local_max   = eps;  // for int8 quant
+  fp32_t r_normalize_shape = 1 / (float)(normalize_shape);
+
+// step 1. compute x + skip
+#pragma unroll
+  for (int32_t it = 0; it < VPT; it++)
+      inLocal[it] = inLocal[it] + weightLocal[it];
+  copy<sizeof(fp16_t) * VPT>(inLocal, &o1[idx]);
+
+#pragma unroll
+  for (int32_t it = 0; it < VPT; it++){
+    auto _x = __half2float(inLocal[it]);
+    auto _w = __half2float(weightLocal[it]);
+
+    accumulator = accumulator + _x * _x;
+    local_max   = max(local_max, abs(_x * _w));
+  }
+  copy<sizeof(fp16_t) * VPT>(&weight[threadIdx.x * VPT], weightLocal);
+
+  using BlockReduce = cub::BlockReduce<fp32_t, TPB>;
+  __shared__ typename BlockReduce::TempStorage tempStorage;
+  __shared__ fp32_t r_reduced;
+
+  const fp32_t global_max = BlockReduce(tempStorage).Reduce(local_max, cub::Max());
+  __syncthreads();
+  const fp32_t reduced = BlockReduce(tempStorage).Reduce(accumulator, cub::Sum()) * r_normalize_shape;
+
+  if (threadIdx.x == 0) {
+    const fp32_t scale = MIN_MAX_TO_SCALE(global_max);
+    o2_scale[blockIdx.x] = __float2half(scale);
+    r_reduced = rsqrt(reduced + eps) * RCP(scale);
+  }
+  __syncthreads();
+
+  int8_t outLocal[VPT];
+#pragma unroll
+  for (int32_t it = 0; it < VPT; it++){
+    fp32_t fp32_value = __half2float(inLocal[it]) * __half2float(weightLocal[it]);
+    outLocal[it] = QUANT_FP32_TO_INT8_RCP(fp32_value, r_reduced);
+  }
+  copy<sizeof(int8_t) * VPT>(outLocal, &o2[idx]);
+};
+
+
+/**
+ * Skip Rmsnorm 与 动态量化 的融合算子
+ * 这个算子会执行 Add, Rmsnorm, Dynamic Quant 三个操作
+ * Dynamic Quant 是指这个算子会在运行时统计输入的 per token min-max 并以此对输入进行量化
+ * 使用公式 int8 value = clip(round(fp16 value / scale), -127, 127)
+ *     其中 scale = abs(max(fp16 value)) / 127
+ * 这个算子会执行 per token 量化，每一个 token 都将拥有一个属于它的 scale
+ *
+ * Skip Rmsnorm 会先执行 y1 = x + skip
+ *              而后执行 y2 = rmsnorm(y1)
+ * 返回 y1, y2 作为输出
+ */
+ppl::common::RetCode skip_rmsnorm_with_minmax_quant_fp16i_int8o(
+  const cudaStream_t stream,
+  const fp16_t *x,                // 输入，形如 [batch, hidden dim]
+  const fp16_t *weight,           // rmsnorm 的权重，形如 [hidden dim]
+  const fp16_t *skip,             // 求和项，这是 skip rmsnorm 中的另一个输入，形如 [batch, hidden dim]
+  const float eps,                // 1e-7
+  const int64_t num_of_batch      // x 第一维的大小
+  const int64_t normalize_shape,  // x 的最后一维大小
+  fp16_t *o1,                     // x + skip, 形如 [batch, hidden dim]
+  fp16_t *o2_scale,               // quant(rmsnorm(x + skip)), 形如 [batch]
+  int8_t *o2                      // quant(rmsnorm(x + skip)), 形如 [batch, hidden dim]
+) {
+/*
+  Merged Impl of Skip Rmsnorm + PerToken Quant(fp16 input, int8 output)
+*/
+  constexpr int32_t VPT = 16 / sizeof(fp16_t);
+  const int32_t grid_size = num_of_batch;
+
+  switch (normalize_shape)
+  {
+  case 768:
+    _skip_rmsnorm_with_minmax_quant_fp16i_int8o<VPT, 768 / VPT>
+    <<<grid_size, 768 / VPT, 0, stream>>>(
+      x,
+      weight,
+      skip,
+      eps, normalize_shape,
+      o1,
+      o2_scale,
+      o2
+    );
+    break;
+  case 1024:
+    _skip_rmsnorm_with_minmax_quant_fp16i_int8o<VPT, 1024 / VPT>
+    <<<grid_size, 1024 / VPT, 0, stream>>>(
+      x,
+      weight,
+      skip,
+      eps, normalize_shape,
+      o1,
+      o2_scale,
+      o2
+    );
+    break;
+  case 4096:
+    _skip_rmsnorm_with_minmax_quant_fp16i_int8o<VPT, 4096 / VPT>
+    <<<grid_size, 4096 / VPT, 0, stream>>>(
+      x,
+      weight,
+      skip,
+      eps, normalize_shape,
+      o1,
+      o2_scale,
+      o2
+    );
+    break;
+  case 8192:
+    _skip_rmsnorm_with_minmax_quant_fp16i_int8o<VPT, 8192 / VPT>
+    <<<grid_size, 8192 / VPT, 0, stream>>>(
+      x,
+      weight,
+      skip,
+      eps, normalize_shape,
+      o1,
+      o2_scale,
+      o2
+    );
+    break;
+  default:
+    LOG(ERROR) << "Input data length must be a multiple of 8.";
+    return ppl::common::RC_UNSUPPORTED;
+    break;
+  };
+  return ppl::common::RC_SUCCESS;
+}

--- a/src/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.cu
@@ -20,7 +20,7 @@
 
 # include <cuda_fp16.h>
 
-namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace pmx {
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
 
 ppl::common::RetCode row_parallel_linear_int8i_int32o(
     const cudaStream_t stream,
@@ -96,4 +96,4 @@ ppl::common::RetCode row_parallel_linear_int8i_int32o(
     return ppl::common::RC_SUCCESS;
 }
 
-}}}}}
+}}}}}}

--- a/src/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/row_parallel_linear.cu
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# include "ppl/kernel/llm/cuda/pmx/row_parallel_linear.h"
+# include "ppl/common/log.h"
+
+# include <cuda_fp16.h>
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace pmx {
+
+ppl::common::RetCode row_parallel_linear_int8i_int32o(
+    const cudaStream_t stream,
+    const cublasLtHandle_t& cublaslt_handle,
+    const cublasLtMatmulAlgo_t* algo,
+    const ppl::common::TensorShape* input_shape,
+    const void* input,
+    const ppl::common::TensorShape* weight_shape,
+    const void* weight,
+    const ppl::common::TensorShape* bias_shape,
+    const void* bias,
+    const int64_t in_features,
+    const int64_t out_features,
+    ppl::common::NcclParam* nccl_param,
+    const bool input_is_parallel,
+    void* split_buffer,
+    const int64_t cublas_workspace_size,
+    void* cublas_workspace,
+    const ppl::common::TensorShape* output_shape,
+    void* output)
+{
+    if (!input_is_parallel) {
+        LOG(ERROR) << "currnetly only support parallel input";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    // input (M, K/w)
+    // weight (N, K/w)
+    // output (M, N)
+
+    const int64_t M = input_shape->CalcElementsToDimensionExcludingPadding(input_shape->GetDimCount() - 1);
+    const int64_t N = out_features;
+    const int64_t Kw = in_features / nccl_param->size;
+
+    ppl::common::RetCode status;
+
+    status = ppl::kernel::llm::cuda::cublas::gemm(
+        stream,
+        cublaslt_handle,
+        algo,
+        false,
+        Kw,
+        input_shape->GetDataType(),
+        input,
+        true,
+        Kw,
+        weight_shape->GetDataType(),
+        weight,
+        bias,
+        M,
+        N,
+        Kw,
+        1.0f,
+        0.0f,
+        cublas_workspace_size,
+        cublas_workspace,
+        N,
+        output_shape->GetDataType(),
+        output);
+
+    if (ppl::common::RC_SUCCESS != status)
+        return status;
+
+    if (nccl_param->size > 1) {
+        return ppl::common::NcclAllReduceSum<half>(
+            (half*)output,
+            (half*)output,
+            M * N,
+            nccl_param,
+            stream);
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}}}

--- a/src/ppl/kernel/llm/cuda/quant/i8/silu.cu
+++ b/src/ppl/kernel/llm/cuda/quant/i8/silu.cu
@@ -1,0 +1,228 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# include "ppl/kernel/llm/cuda/quant/i8/silu.h"
+# include "ppl/common/log.h"
+
+using namespace ppl::kernel::llm::cuda::quant;
+
+namespace ppl { namespace kernel { namespace llm { namespace cuda { namespace quant { namespace i8 {
+
+__DEVICE_INLINE_FUNCTION__
+fp32_t __silu_fp32(const fp32_t val){
+    return val / (1.f + __expf(-val));
+}
+
+__DEVICE_INLINE_FUNCTION__
+fp32_t __silu_fp16(const fp16_t val){
+    auto fp32 = __half2float(val);
+    return fp32 / (1.f + __expf(-fp32));
+}
+
+/*
+ * Silu 与 token-channel 解量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 silu(input) * gate
+ * 这个函数要求其输入排布是 col32 的，可由参数 ConvertLayoutToRowMajor 决定在输出时是否使用 row major 排布
+*/
+template<bool GATED, int32_t TPB, bool ConvertLayoutToRowMajor>
+__global__ 
+void _silu_i32_fp16_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token]
+    const fp16_t  *gate_channel_scale    // [hidden_dim]
+    fp16_t        *fp16_output            // [num_of_token, hidden_dim]
+) {
+    const int32_t token_id = blockIdx.x;
+    auto layout_converter = LayoutConverter(num_of_token, hidden_dim);
+    for(int32_t i = threadIdx.x; i < hidden_dim; i += TPB) {
+        const int32_t col32_offset = layout_converter.RowColToOffset(token_id, i);
+
+        const int32_t input = input[col32_offset];
+        const fp32_t  dq_input = input * (
+            __half2float(input_token_scale[token_id]) * 
+            __half2float(input_channel_scale[i])
+        );
+
+        fp32_t ret = __silu_fp32(de_input);
+
+        if(GATED) {
+            int32_t gate = gate[col32_offset];
+            fp32_t  dq_gate = gate * (
+                __half2float(gate_token_scale[token_id]) * 
+                __half2float(gate_channel_scale[i])
+            );
+            ret *= gate;
+        }
+        
+        if (ConvertLayoutToRowMajor){
+            fp16_output[layout_converter.Col32ToRowMajor(col32_offset)] = __float2half(ret);
+        } else{
+            fp16_output[col32_offset] = __float2half(ret);
+        }
+    }
+}
+
+/*
+ * Silu 与 token-channel 解量化 与 token 量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize, Quantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 output_fp16 = silu(input) * gate
+ * 最后执行 output_int8 = dynamic per token quantize(output_fp16)
+ * 这个函数要求其输入输出排布均是 col32 的
+ * 
+ * 这个函数执行动态 per token 量化，
+*/
+template<bool GATED, int32_t TPB>
+__global__ 
+void _silu_i32_i8_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token]
+    const fp16_t  *gate_channel_scale    // [hidden_dim]
+    fp16_t        *workspace             // [num_of_token, hidden_dim]
+    int8_t        *int8_output)          // [num_of_token, hidden_dim]
+{
+    constexpr int32_t WARP_SIZE = 32;
+    constexpr int32_t WPT       = 32;    // warp per thread block.
+    const int32_t token_id = blockIdx.x;
+    auto layout_converter = LayoutConverter(num_of_token, hidden_dim);
+
+    fp32_t local_max = 0.0;
+    __shared__ fp32_t red_smem[WPT];
+
+    for(int32_t i = threadIdx.x; i < hidden_dim; i += TPB) {
+        const int32_t col32_offset = layout_converter.RowColToOffset(token_id, i);
+
+        const int32_t input = input[col32_offset];
+        const fp32_t  dq_input = input * (
+            __half2float(input_token_scale[token_id]) * 
+            __half2float(input_channel_scale[i])
+        );
+
+        fp32_t ret = __silu_fp32(de_input);
+
+        if(GATED) {
+            int32_t gate = gate[col32_offset];
+            fp32_t  dq_gate = gate * (
+                __half2float(gate_token_scale[token_id]) * 
+                __half2float(gate_channel_scale[i])
+            );
+            ret *= gate;
+        }
+
+        local_max = max(abs(ret), local_max);
+        workspace[col32_offset] = __float2half(ret);
+    }
+
+    local_max = __BlockReduceMax<WPT>(local_max, red_smem);
+    // quantize from workspace(fp16) to output(int8)
+    fp32_t scale_rcp = RCP(local_max / 127);
+    
+    for(int32_t i = threadIdx.x; i < hidden_dim; i += TPB) {
+        const int32_t col32_offset = layout_converter.RowColToOffset(token_id, i);
+        const fp16_t input = workspace[col32_offset];
+
+        int8_output[col32_offset] = QUANT_FP32_TO_INT8_RCP(input, scale_crp);
+    }
+}
+
+/*
+ * Silu 与 token-channel 解量化 与 token 量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize, Quantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 output_fp16 = silu(input) * gate
+ * 最后执行 output_int8 = dynamic per token quantize(output_fp16)
+ * 这个函数要求其输入输出排布均是 col32 的
+ * 
+ * 这个函数执行动态 per token 量化，
+*/
+template<bool GATED>
+ppl::common::RetCode silu_i32_i8_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32, 没有就直接传空指针
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token], 没有就直接传空指针
+    const fp16_t  *gate_channel_scale    // [hidden_dim], 没有就直接传空指针
+    fp16_t        *workspace             // [num_of_token, hidden_dim]
+    int8_t        *int8_output           // [num_of_token, hidden_dim]
+) {
+    const int64_t TPB = 256;
+    // 这个 kernel 需要沿着 token 维度统计量化信息，所以每一个 thread block 只负责处理一个 token 的内容
+    const int32_t num_of_thread_block = num_of_token; 
+
+    _silu_i32_i8_col32<GATED, TPB>
+    <<<num_of_thread_block, TPB, 0, stream>>> (
+        input, gate, num_of_token, hidden_dim,
+        input_token_scale, input_channel_scale,
+        gate_token_scale, gate_channel_scale,
+        workspace, int8_output
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+
+/*
+ * Silu 与 token-channel 解量化 的融合算子
+ * 这个算子会执行 Silu, Mul, Dequantize 三个操作
+ * 其两个输入 input, gate 将首先被解量化到 fp16
+ * 而后执行 silu(input) * gate
+ * 这个函数要求其输入排布是 col32 的，可由参数 ConvertLayoutToRowMajor 决定在输出时是否使用 row major 排布
+*/
+template<bool GATED, bool ConvertLayoutToRowMajor>
+ppl::common::RetCode _silu_i32_fp16_col32(
+    const int32_t *input,                // [num_of_token, hidden_dim] layout: col32
+    const int32_t *gate,                 // [num_of_token, hidden_dim] layout: col32
+    const int64_t num_of_token,
+    const int64_t hidden_dim,
+    fp16_t        *input_token_scale     // [num_of_token]
+    const fp16_t  *input_channel_scale   // [hidden_dim]
+    fp16_t        *gate_token_scale      // [num_of_token]
+    const fp16_t  *gate_channel_scale    // [hidden_dim]
+    fp16_t        *fp16_output           // [num_of_token, hidden_dim]
+) {
+    const int64_t TPB = 256;
+    // 这个 kernel 虽然不需要沿着 token 维度统计量化信息
+    // 但我懒得改了，希望有缘人把它改写成另外的写法
+    const int32_t num_of_thread_block = num_of_token;
+
+    _silu_i32_fp16_col32<GATED, TPB, ConvertLayoutToRowMajor>
+    <<<num_of_thread_block, TPB, 0, stream>>> (
+        input, gate, num_of_token, hidden_dim,
+        input_token_scale, input_channel_scale,
+        gate_token_scale, gate_channel_scale,
+        fp16_output
+    );
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}}}}


### PR DESCRIPTION
* Add following kernels:
  * groupwise_minmax_dequantize_int8i_fp16o
  * groupwise_minmax_quantize_int8i_fp16o
  * channelwise_minmax_quantize_fp16i_i8o
  * tokenwise_minmax_quantize_fp16i_i8o
  * token_channel_dequantize_i32i_f16o
  * skip_rmsnorm_with_minmax_quant_fp16i_int8o
  * silu_i32_fp16_col32
  * silu_i32_i8_col32
  * row_parallel_linear_int8i_int32o
  * column_parallel_linear_int8i_int32o

kernels have been tested with python JIT, but not with ppl.