### PR TITLE
[fix] fix sample.cu bug

### DIFF
--- a/src/ppl/kernel/llm/cuda/pmx/sample.cu
+++ b/src/ppl/kernel/llm/cuda/pmx/sample.cu
@@ -424,14 +424,18 @@ void sample_argmax_kernel(
     // initilize shared memory
     constexpr int32_t WARP_SIZE = 32;
     constexpr int32_t WPT = TPB / WARP_SIZE;
+    constexpr int32_t RED_SMEM_SIZE = WPT + WARP_SIZE;
+
     __shared__ int32_t buffer[TPB];
-    __shared__ fp32_t red_smem[WPT];
+    __shared__ fp32_t red_smem[RED_SMEM_SIZE];
+
     buffer[threadIdx.x] = selection_idx;
     __syncthreads();
 
     SortingPair p = sample_block_reduce_max_with_index<WPT>(selecting_value, red_smem);
-    if (threadIdx.x == 0)
+    if (threadIdx.x == 0){
         output[batch_id] = buffer[p.index];
+    }
 }
 
 ppl::common::RetCode sample_argmax(


### PR DESCRIPTION
最近在ppl.nn 运行llama的demo时发现 top_k = 1, top_p = 0时会出现cuda 访问内存的异常(cudaErrorIllegalAddress).

会走这个逻辑
<img width="966" alt="image" src="https://github.com/openppl-public/ppl.llm.kernel.cuda/assets/136677540/fc3bd116-5e8c-4435-88ed-729987d3624e">

会在调用这个函数的时候出错：
<img width="860" alt="image" src="https://github.com/openppl-public/ppl.llm.kernel.cuda/assets/136677540/d6a55872-c143-4a0d-9b91-c9b9e9a01741">

在这里越界的：
<img width="779" alt="image" src="https://github.com/openppl-public/ppl.llm.kernel.cuda/assets/136677540/c2819a75-d55f-420f-8241-a3d3294f7c1a">

